### PR TITLE
Changes for Docker Deployment

### DIFF
--- a/docker/scheduler/Dockerfile
+++ b/docker/scheduler/Dockerfile
@@ -1,0 +1,3 @@
+FROM mass_server:latest
+
+ENTRYPOINT mass_scheduler

--- a/mass_server/app.py
+++ b/mass_server/app.py
@@ -61,10 +61,21 @@ def _load_config(app, debug=False, testing=False):
         app.config['TESTING'] = True
     if debug == True:
         app.config['DEBUG'] = True
-    if testing == False:
-        app.config.from_pyfile('application.cfg')
-    else:
-        app.config.from_pyfile('testing.cfg')
+
+    mongo_host = os.getenv('MONGO_HOST', None)
+    if mongo_host:
+        app.config['MONGODB_SETTINGS'] = {
+            'host': mongo_host,
+            'tz_aware': True
+        }
+
+    try:
+        if testing == False:
+            app.config.from_pyfile('application.cfg')
+        else:
+            app.config.from_pyfile('testing.cfg')
+    except FileNotFoundError:
+        print('Could not load config file. Using default config.')
 
 
 # Bootstrap app

--- a/mass_server/app.py
+++ b/mass_server/app.py
@@ -28,6 +28,13 @@ class DefaultConfig(object):
 
 # Generate or load secret key
 def _load_or_generate_secret_key(app):
+    # Check if the secret is set in the environment variables
+    env_secret = os.getenv('FLASK_SECRET', None)
+    if env_secret:
+        app.secret_key = env_secret
+        return
+
+    # If not try to read it from file
     secret_file_name = 'secret.txt'
     try:
         app.secret_key = app.open_instance_resource(


### PR DESCRIPTION
 - Use environment variables to get the flask secret. This fixes the problem of invalid csrf tokens.
 - Get the mongo host from ENV and ignore missing config files.
 - Added an Dockerfile for the scheduler